### PR TITLE
Event driven trigger with workflow_run

### DIFF
--- a/.github/workflows/pr_updater.yml
+++ b/.github/workflows/pr_updater.yml
@@ -1,11 +1,11 @@
 name: Update PR comments
 
 on:
-  # This number should correspond to the IGNORE_RUNS_OLDER_THAN value below.
-  # When setting up for the first time, use "on: push" instead of "on: schedule"
-  # and set IGNORE_RUNS_OLDER_THAN to a very high number until it runs once.
-  schedule:
-    - cron: '*/15 * * * *'
+  workflow_run:
+    workflows:
+      - Demo CI
+    types:
+      - completed
 
 jobs:
   pr_updater:
@@ -20,10 +20,10 @@ jobs:
           MSG_ARTIFACT_NAME: "pr_message"
           # How far back to look for finished runs, in minutes.
           # Set to 10-20 minutes higher than cron's job frequency set above.
-          IGNORE_RUNS_OLDER_THAN: 30
+          IGNORE_RUNS_OLDER_THAN: 2
           # How far back to look for updated pull requests, in minutes.
           # Should be bigger than IGNORE_RUNS_OLDER_THAN by the maximum time a pull request jobs may take
-          IGNORE_PRS_OLDER_THAN: 80
+          IGNORE_PRS_OLDER_THAN: 10
         run: |
           #
           # Strategy:


### PR DESCRIPTION
Now that [`workflow_run`](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_run) is available, runs can be completely event driven and cron is not required.